### PR TITLE
Add an option for minimum interval between notifications - updated

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -399,6 +399,12 @@
         notification, it won\'t vibrate for notifications from this app for next 10 seconds. Useful for group chat notifications where
         lots of messages can be sent in very short time. Set to 0 to disable.
     </string>
+    <string name="settingMinimumNotificationInterval">Minimum notification interval</string>
+    <string name="settingMinimumNotificationIntervalDescription">Allows you to specify minimum amount of seconds that must
+        pass between two notifications for the second to be sent to Pebble. For example if you set this to 10 and you receive a
+        notification, further notifications from this app  won\'t be sent to Pebble for next 10 seconds. Useful for group chat
+        notifications where lots of messages can be sent in very short time. Set to 0 to disable.
+    </string>
     <string name="settingRespectInterruptFilter">Respect Android\'s \"Don\'t interrupt\" setting</string>
     <string name="settingRespectInterruptFilterDescription">If \"Don\'t interrupt\" setting is enabled in your Android
         settings, notifications that are set to not interrupt you also won\'t be sent to the Pebble. Only works on

--- a/src/com/matejdro/pebblenotificationcenter/appsetting/AppSetting.java
+++ b/src/com/matejdro/pebblenotificationcenter/appsetting/AppSetting.java
@@ -44,6 +44,7 @@ public enum AppSetting
     VIBRATION_PATTERN("vibrationPattern", "500"),
     PERIODIC_VIBRATION("settingPeriodicVibration", "20"),
     MINIMUM_VIBRATION_INTERVAL("minimumVibrationInterval", "0"),
+    MINIMUM_NOTIFICATION_INTERVAL("minimumNotificationInterval", "0"),
     INCLUDED_REGEX("WhitelistRegexes", null),
     EXCLUDED_REGEX("BlacklistRegexes", null);
 

--- a/src/com/matejdro/pebblenotificationcenter/ui/perapp/PerAppActivity.java
+++ b/src/com/matejdro/pebblenotificationcenter/ui/perapp/PerAppActivity.java
@@ -135,6 +135,7 @@ public class PerAppActivity extends Activity
         category.add(new VibrationPatternItem(settingsStorage, R.string.settingVibrationPattern, R.string.settingVibrationPatternDescription));
         category.add(new EditTextItem(settingsStorage, AppSetting.PERIODIC_VIBRATION, InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL, R.string.settingPeriodicVibration, R.string.settingPeriodicVibrationDescription));
         category.add(new EditTextItem(settingsStorage, AppSetting.MINIMUM_VIBRATION_INTERVAL, InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL, R.string.settingMinimumVibrationInterval, R.string.settingMinimumVibrationIntervalDescription));
+        category.add(new EditTextItem(settingsStorage, AppSetting.MINIMUM_NOTIFICATION_INTERVAL, InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_NORMAL, R.string.settingMinimumNotificationInterval, R.string.settingMinimumNotificationIntervalDescription));
         settings.add(new SettingsCategory(R.string.settingsCategoryVibration, category));
 
         //Regex


### PR DESCRIPTION
This is useful if you don't want certain apps to constantly send notifications
to your Pebble, when you are already aware of them. This is similar to the
minimum interval between notifications, except it won't even send the
notification to the Pebble at all. It's just a quick patch though.

I'm not sure if this is a feature that you are interested in, but it's something
which I needed, and figured I might as well offer. It's helpful when you want
to try to help save Pebble battery, while having many IM conversations.

Possible room for improvement would be "notify once for this app" feature,
so that if an app has the "top" notification, it wouldn't re-notify the Pebble.
That might already be part of the app though.
