### PR TITLE
Lsposed support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -120,6 +120,9 @@
         <meta-data
             android:name="xposedsharedprefs"
             android:value="true" />
+        <meta-data
+            android:name="xposedscope"
+            android:resource="@array/module_scope" />
         <meta-data android:name="com.crashlytics.ApiKey" android:value="048e0255b748bd3c0abc33c75a2601ff67b550c8"/>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,6 +117,9 @@
         <meta-data
             android:name="xposedminversion"
             android:value="54" />
+        <meta-data
+            android:name="xposedsharedprefs"
+            android:value="true" />
         <meta-data android:name="com.crashlytics.ApiKey" android:value="048e0255b748bd3c0abc33c75a2601ff67b550c8"/>
     </application>
 

--- a/app/src/main/res/values/module_scope.xml
+++ b/app/src/main/res/values/module_scope.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="module_scope">
+        <item>com.getpebble.android.basalt</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
Added support for LSPosed framework (XPosed for Magisk with some new features). The first commit activates their new shared preferences (as far as I understood they broke them and the rework somehow). The second one made lsposed enable NC exposed module for pebble app by default. Both changes tested and worked fine on A10 + Magisk 23 + Riru 26 + Lsposed 1.6.5. As far as I understand other xposed variants will just ignore new properties (both are lsposed specific) so it is safe to add them. Anyway, classic xposed is not updated for many years, edxposed is dead for a year now, and lsposed is the only actively maintained xposed variant.
Fixes #106 